### PR TITLE
Removing `install_requires` because it forces Django to be downloaded wh...

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,5 @@ setup(
       license = 'New BSD License',
       platforms = ['OS Independent'],
       classifiers = CLASSIFIERS,
-      install_requires = ['Django>=1.3.1'],
       packages = find_packages() 
 )


### PR DESCRIPTION
...en installing via `pip`.

Every time django-gravatar is installed, the whole Django application installs as well. No bueno.
